### PR TITLE
Add Speed-relative Head Bop

### DIFF
--- a/ESC Every Second Count/Assets/Scenes/PhysicsTest V2.unity
+++ b/ESC Every Second Count/Assets/Scenes/PhysicsTest V2.unity
@@ -2061,6 +2061,7 @@ GameObject:
   - component: {fileID: 2139646838}
   - component: {fileID: 2139646842}
   - component: {fileID: 2139646837}
+  - component: {fileID: 2139646843}
   m_Layer: 0
   m_Name: PlayerV2
   m_TagString: Player
@@ -2120,7 +2121,7 @@ MeshRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2139646836}
   m_Enabled: 1
-  m_CastShadows: 1
+  m_CastShadows: 3
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
   m_MotionVectors: 1
@@ -2192,6 +2193,25 @@ Rigidbody:
   m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
+--- !u!114 &2139646843
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2139646836}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fabefda5907c7584eab1292ee834ec5a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _enable: 1
+  _amplitude: 0.01
+  _walkFrequency: 20
+  _runFrequency: 30
+  _camera: {fileID: 1239024007}
+  _cameraHolder: {fileID: 1546563901}
+  playerHeight: 2
 --- !u!1 &2143332272
 GameObject:
   m_ObjectHideFlags: 0

--- a/ESC Every Second Count/Assets/Scripts/CameraController2.cs
+++ b/ESC Every Second Count/Assets/Scripts/CameraController2.cs
@@ -35,7 +35,7 @@ public class CameraController2 : MonoBehaviour
 
     void FixedUpdate()
     {
-        float addedFov = rb.velocity.magnitude - 3.44f;
+        float addedFov = rb.velocity.magnitude*2 - 3.44f;
         fov = Mathf.Lerp(fov, baseFov + addedFov, 0.5f);
         fov = Mathf.Clamp(fov, baseFov, maxFov);
         mainCamera.fieldOfView = fov;

--- a/ESC Every Second Count/Assets/Scripts/HeadBop.cs
+++ b/ESC Every Second Count/Assets/Scripts/HeadBop.cs
@@ -1,0 +1,73 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class HeadBop : MonoBehaviour
+{
+    [SerializeField] private bool _enable = true;
+
+    [SerializeField, Range(0, 0.1f)] private float _amplitude = 0.01f;
+    [SerializeField, Range(0, 30)] private float _walkFrequency = 20.0f;
+    [SerializeField, Range(0, 30)] private float _runFrequency = 30.0f;
+
+    [SerializeField] private Transform _camera = null;
+    [SerializeField] private Transform _cameraHolder = null;
+
+    private float _toggleSpeed = 3.0f;
+    private Vector3 _startPos;
+
+    Rigidbody _rb;
+    [SerializeField] private float playerHeight = 2.0f;
+
+    private void Awake()
+    {
+        _rb = GetComponent<Rigidbody>();
+        _startPos = _camera.localPosition;
+    }
+
+    void Update()
+    {
+        if (!_enable) return;
+
+        ResetPosition();
+
+        if (_rb.velocity.magnitude > 6.1f) CheckMotion(_runFrequency);
+        else CheckMotion(_walkFrequency);
+    }
+
+    private void PlayMotion(Vector3 motion)
+    {
+        _camera.localPosition += motion;
+    }
+
+    private void CheckMotion(float _frequency)
+    {
+        float speed = new Vector3(_rb.velocity.x, 0, _rb.velocity.z).magnitude;
+        
+        if (speed < _toggleSpeed) return;
+        if (!Physics.Raycast(transform.position + Vector3.up * 0.01f, Vector3.down, playerHeight * 0.5f)) return;
+        
+        PlayMotion(FootStepMotion(_frequency));
+    }
+
+    private Vector3 FootStepMotion(float _frequency)
+    {
+        Vector3 pos = Vector3.zero;
+        pos.y += Mathf.Sin(Time.time * _frequency) * _amplitude;
+        pos.x += Mathf.Cos(Time.time * _frequency / 2) * _amplitude * 2;
+        return pos;
+    }
+
+    private void ResetPosition()
+    {
+        if (_camera.localPosition == _startPos) return;
+        _camera.localPosition = Vector3.Lerp(_camera.localPosition, _startPos, 1 * Time.deltaTime);
+    }
+
+    private Vector3 FocusTarget()
+    {
+        Vector3 pos = new Vector3(transform.position.x, transform.position.y + _cameraHolder.localPosition.y, transform.position.z);
+        pos += _cameraHolder.forward * 15.0f;
+        return pos;
+    }
+}

--- a/ESC Every Second Count/Assets/Scripts/HeadBop.cs.meta
+++ b/ESC Every Second Count/Assets/Scripts/HeadBop.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fabefda5907c7584eab1292ee834ec5a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ESC Every Second Count/Packages/manifest.json
+++ b/ESC Every Second Count/Packages/manifest.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
-    "com.unity.collab-proxy": "1.15.4",
+    "com.unity.collab-proxy": "1.15.9",
     "com.unity.ide.rider": "2.0.7",
-    "com.unity.ide.visualstudio": "2.0.12",
+    "com.unity.ide.visualstudio": "2.0.14",
     "com.unity.ide.vscode": "1.2.4",
     "com.unity.mathematics": "1.2.5",
     "com.unity.postprocessing": "3.1.1",

--- a/ESC Every Second Count/Packages/packages-lock.json
+++ b/ESC Every Second Count/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.collab-proxy": {
-      "version": "1.15.4",
+      "version": "1.15.9",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -27,7 +27,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.visualstudio": {
-      "version": "2.0.12",
+      "version": "2.0.14",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
1. Player head now bops while walking and running with different frequency (customizable) (on ground only).
2. Player character now isn't rendered in the camera, just shadow only (prevent model glitch from camera shaking).